### PR TITLE
Adding support for base64Encode

### DIFF
--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1186,8 +1186,8 @@ export namespace google {
                     /** GetDeviceRequest fieldMask */
                     fieldMask?: (google.protobuf.IFieldMask|null);
 
-                    /** GetDeviceRequest base64Encode */
-                    base64Encode?: (string|null);
+                    /** GetDeviceRequest base64Encode - if supplied, the state data in the state field will be base64 encoded */
+                    base64Encode?: boolean;
                 }
 
                 /** Represents a GetDeviceRequest. */
@@ -1507,8 +1507,8 @@ export namespace google {
                     /** ListDevicesRequest pageToken */
                     pageToken?: (string|null);
 
-                    /** Boolean base64Encode */
-                    base64Encode?: (string|null);
+                    /** Boolean base64Encode - if supplied, the state data in the state field will be base64 encoded */
+                    base64Encode?: boolean;
                 }
 
                 /** Represents a ListDevicesRequest. */

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1186,7 +1186,7 @@ export namespace google {
                     /** GetDeviceRequest fieldMask */
                     fieldMask?: (google.protobuf.IFieldMask|null);
 
-                    /** GetDeviceRequest base64Encode - if supplied, the state data in the state field will be base64 encoded */
+                    /** boolean base64Encode - if supplied, the state data in the state field will be base64 encoded */
                     base64Encode?: boolean;
                 }
 
@@ -1507,7 +1507,7 @@ export namespace google {
                     /** ListDevicesRequest pageToken */
                     pageToken?: (string|null);
 
-                    /** Boolean base64Encode - if supplied, the state data in the state field will be base64 encoded */
+                    /** boolean base64Encode - if supplied, the state data in the state field will be base64 encoded */
                     base64Encode?: boolean;
                 }
 

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1185,6 +1185,9 @@ export namespace google {
 
                     /** GetDeviceRequest fieldMask */
                     fieldMask?: (google.protobuf.IFieldMask|null);
+
+                    /** GetDeviceRequest base64Encode */
+                    base64Encode?: (string|null);
                 }
 
                 /** Represents a GetDeviceRequest. */
@@ -1503,6 +1506,9 @@ export namespace google {
 
                     /** ListDevicesRequest pageToken */
                     pageToken?: (string|null);
+
+                    /** Boolean base64Encode */
+                    base64Encode?: (string|null);
                 }
 
                 /** Represents a ListDevicesRequest. */

--- a/src/v1/device_manager_client.ts
+++ b/src/v1/device_manager_client.ts
@@ -1325,7 +1325,6 @@ export class DeviceManagerClient {
     protos.google.cloud.iot.v1.IDevice
   >(
     async request => {
-      console.log('ANS here!!!!');
       const registry = this.matchRegistryFromDeviceName(request?.name ?? '');
       const region = this.matchLocationFromDeviceName(request?.name ?? '');
       const token_response = await this.getRegistryToken(registry, region);

--- a/src/v1/device_manager_client.ts
+++ b/src/v1/device_manager_client.ts
@@ -1325,6 +1325,7 @@ export class DeviceManagerClient {
     protos.google.cloud.iot.v1.IDevice
   >(
     async request => {
+      console.log('ANS here!!!!');
       const registry = this.matchRegistryFromDeviceName(request?.name ?? '');
       const region = this.matchLocationFromDeviceName(request?.name ?? '');
       const token_response = await this.getRegistryToken(registry, region);
@@ -1333,7 +1334,9 @@ export class DeviceManagerClient {
           host: token_response.host,
           path: `/api/v/4/webhook/execute/${
             token_response.systemKey
-          }/cloudiot_devices?name=${request.name}${
+          }/cloudiot_devices?name=${request.name}&base64Encode=${
+            request.base64Encode
+          }${
             typeof request.fieldMask !== 'undefined' &&
             request.fieldMask !== null &&
             typeof request.fieldMask.paths !== 'undefined' &&
@@ -3529,6 +3532,10 @@ export class DeviceManagerClient {
 
         if (request.pageToken) {
           searchParams.set('pageToken', request.pageToken);
+        }
+
+        if (request.base64Encode) {
+          searchParams.set('base64Encode', request.base64Encode);
         }
 
         function getGatewayType(

--- a/src/v1/device_manager_client.ts
+++ b/src/v1/device_manager_client.ts
@@ -1328,21 +1328,30 @@ export class DeviceManagerClient {
       const registry = this.matchRegistryFromDeviceName(request?.name ?? '');
       const region = this.matchLocationFromDeviceName(request?.name ?? '');
       const token_response = await this.getRegistryToken(registry, region);
+      const searchParams = new URLSearchParams();
+      if (typeof request.name === 'string') {
+        searchParams.set('name', request.name);
+      }
+      if (
+        typeof request.fieldMask !== 'undefined' &&
+        request.fieldMask !== null &&
+        typeof request.fieldMask.paths !== 'undefined' &&
+        request.fieldMask.paths !== null
+      ) {
+        searchParams.set('fieldMask', request.fieldMask.paths.join(','));
+      }
+      if (typeof request.base64Encode !== 'undefined') {
+        searchParams.set(
+          'base64Encode',
+          request.base64Encode ? 'true' : 'false'
+        );
+      }
       return new Promise((resolve, reject) => {
         const options = {
           host: token_response.host,
           path: `/api/v/4/webhook/execute/${
             token_response.systemKey
-          }/cloudiot_devices?name=${request.name}&base64Encode=${
-            request.base64Encode
-          }${
-            typeof request.fieldMask !== 'undefined' &&
-            request.fieldMask !== null &&
-            typeof request.fieldMask.paths !== 'undefined' &&
-            request.fieldMask.paths !== null
-              ? `&fieldMask=${request.fieldMask.paths.join(',')}`
-              : ''
-          }`,
+          }/cloudiot_devices?${searchParams.toString()}`,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
@@ -3533,8 +3542,11 @@ export class DeviceManagerClient {
           searchParams.set('pageToken', request.pageToken);
         }
 
-        if (request.base64Encode) {
-          searchParams.set('base64Encode', request.base64Encode);
+        if (typeof request.base64Encode !== 'undefined') {
+          searchParams.set(
+            'base64Encode',
+            request.base64Encode === true ? 'true' : 'false'
+          );
         }
 
         function getGatewayType(


### PR DESCRIPTION
@clarkbynum @ronak-ingress not ready to merge this yet. The changes in this SDK are to enable API tests to test the new base64Encode flag for encoding/not encoding device states.

For the moment I'm using this PR to see what files changed.