### PR TITLE
Allows requesting device states as base64-encoded or not

### DIFF
--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -2151,6 +2151,9 @@ export namespace google {
 
                     /** ListDeviceStatesRequest numStates */
                     numStates?: (number|null);
+
+                    /** boolean base64Encode - if supplied, the state data in the state field will be base64 encoded */
+                    base64Encode?: boolean;
                 }
 
                 /** Represents a ListDeviceStatesRequest. */

--- a/src/v1/device_manager_client.ts
+++ b/src/v1/device_manager_client.ts
@@ -2193,9 +2193,9 @@ export class DeviceManagerClient {
           query.append(
             'base64Encode',
             typeof request.base64Encode === 'boolean'
-            ? request.base64Encode?.toString()
-            : 'false'
-          )
+              ? request.base64Encode?.toString()
+              : 'false'
+          );
         }
 
         const options = {

--- a/src/v1/device_manager_client.ts
+++ b/src/v1/device_manager_client.ts
@@ -2189,6 +2189,13 @@ export class DeviceManagerClient {
         );
         if (isBinaryDataFormat()) {
           query.append('base64Encode', 'true');
+        } else {
+          query.append(
+            'base64Encode',
+            typeof request.base64Encode === 'boolean'
+            ? request.base64Encode?.toString()
+            : 'false'
+          )
         }
 
         const options = {


### PR DESCRIPTION
Among other things, the change to protos.d.ts here is needed for new iotcore API tests for checking changes to listDeviceStates. 🦕
